### PR TITLE
widen small integer eltype to avoid InexactError (fixes #15)

### DIFF
--- a/src/IntegralArrays.jl
+++ b/src/IntegralArrays.jl
@@ -104,18 +104,20 @@ function IntegralArray{T}(data::AbstractArray, A::AbstractArray) where {T}
 end
 
 IntegralArray(A::AbstractArray) = IntegralArray{_maybe_floattype(eltype(A))}(A)
-IntegralArray(data::AbstractArray, A::AbstractArray) = IntegralArray{_maybe_floattype(eltype(data))}(data, A)
+IntegralArray(data::AbstractArray, A::AbstractArray) =
+    IntegralArray{_maybe_floattype(eltype(data))}(data, A)
 
-let smallints = (Int === Int64 ?
-                Union{Int8, UInt8, Int16, UInt16, Int32, UInt32} :
-                Union{Int8, UInt8, Int16, UInt16})
-    global IntegralArray
-    notsmallint(T::Type{<:Integer}) = T <: Signed ? Int : UInt
-    IntegralArray(A::AbstractArray{T}) where {T <: smallints} =
-        IntegralArray{_maybe_floattype(notsmallint(T))}(A)
-    IntegralArray(data::AbstractArray{T}, A::AbstractArray) where {T <: smallints} =
-        (U = _maybe_floattype(notsmallint(T)); IntegralArray{U}(U.(data), A))
+# small integer eltypes almost certainly hit overflow issues (#15)
+const SmallInt = @static if Int === Int64
+    Union{Int8, UInt8, Int16, UInt16, Int32, UInt32}
+else
+    Union{Int8, UInt8, Int16, UInt16}
 end
+_widen(::Type{T}) where T<:SmallInt = T <: Signed ? Int : UInt
+IntegralArray(A::AbstractArray{T}) where T<:SmallInt =
+    IntegralArray{_maybe_floattype(_widen(T))}(A)
+IntegralArray(data::AbstractArray{T}, A::AbstractArray) where T<:SmallInt =
+    throw(ArgumentError("Small integer eltype $(T) would cause potential overflow issue, please use more bits for buffer array."))
 
 Base.IndexStyle(::Type{IntegralArray{T,N,A}}) where {T,N,A} = IndexStyle(A)
 Base.size(A::IntegralArray) = size(A.data)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,6 +78,15 @@ end
         IntegralArray(X, X)
         @test iX == X == IntegralArray(reshape(1:25, 5, 5))
     end
+    
+    @testset "small types" begin
+        X = Int8.(collect(reshape(1:25, 5, 5)))
+        iX = similar(X)
+        iA = IntegralArray(X)
+        @test eltype(iA) == Int
+        IntegralArray(iX, X)
+        @test eltype(iX) == Int
+    end
 end
 
 @testset "Color integral arrays" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -80,12 +80,14 @@ end
     end
     
     @testset "small types" begin
-        X = Int8.(collect(reshape(1:25, 5, 5)))
-        iX = similar(X)
-        iAa = IntegralArray(X)
-        iAb = IntegralArray(iX, X)
-        @test eltype(iAa) == Int
-        @test eltype(iAb) == Int
+        # X = collect(reshape(Int8(1):Int8(25), 5, 5))
+        A = rand(Int8, 5, 5)
+        X = similar(A)
+        iA = IntegralArray(A)
+        @test eltype(iA) == Int
+        @test_throws ArgumentError IntegralArray(X, A)
+        @test_throws InexactError IntegralArray{Int8}(A)
+        @test_throws InexactError IntegralArray{Int8}(X, A)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -82,10 +82,10 @@ end
     @testset "small types" begin
         X = Int8.(collect(reshape(1:25, 5, 5)))
         iX = similar(X)
-        iA = IntegralArray(X)
-        @test eltype(iA) == Int
-        IntegralArray(iX, X)
-        @test eltype(iX) == Int
+        iAa = IntegralArray(X)
+        iAb = IntegralArray(iX, X)
+        @test eltype(iAa) == Int
+        @test eltype(iAb) == Int
     end
 end
 


### PR DESCRIPTION
Give `IntegralArray` a parametric constructor, and better handling of types which might potentially overflow.

P.S., I mention the wrong issue in a couple of my commits—I meant to mention issue #15; my apologies.

fixes #15 